### PR TITLE
Add new command 'copy GitHub link to clipboard'

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "vscode": "0.10.x"
     },
     "activationEvents": [
-        "onCommand:extension.openInGitHub"
+        "onCommand:extension.openInGitHub",
+        "onCommand:extension.copyGitHubLinkToClipboard"
     ],
     "main": "./src/extension",
     "contributes": {
@@ -33,6 +34,10 @@
             {
                 "command": "extension.openInGitHub",
                 "title": "Open in GitHub"
+            },
+            {
+                "command": "extension.copyGitHubLinkToClipboard",
+                "title": "Copy GitHub link to clipboard"
             }
         ],
         "keybindings": [
@@ -40,6 +45,11 @@
                 "command": "extension.openInGitHub",
                 "key": "ctrl+l g",
                 "mac": "ctrl+l g"
+            },
+            {
+                "command": "extension.copyGitHubLinkToClipboard",
+                "key": "ctrl+l c",
+                "mac": "ctrl+l c"
             }
         ]
     },
@@ -52,6 +62,7 @@
         "vscode": "0.10.1"
     },
     "dependencies": {
+        "copy-paste": "^1.1.4",
         "github-url-from-git": "^1.4.0",
         "parse-git-config": "^0.3.1"
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -13,6 +13,7 @@ var git = require('parse-git-config');
 var exec = require('child_process').exec;
 var parse = require('github-url-from-git');
 var open = require('./open');
+var copy = require('copy-paste').copy
 
 function findBranch(config) {
     for (var prop in config) {
@@ -24,7 +25,7 @@ function findBranch(config) {
     return "master";
 }
 
-function openInGitHub() {
+function getGitHubLink(cb) {
     var cwd = workspace.rootPath;
 
     git({
@@ -75,12 +76,21 @@ function openInGitHub() {
         }
 
         if (gitLink)
-            open(gitLink);
+            cb(gitLink);
     });
+}
+
+function openInGitHub() {
+	getGitHubLink(open);
+}
+
+function copyGitHubLinkToClipboard() {
+	getGitHubLink(copy);
 }
 
 function activate(context) {
     context.subscriptions.push(commands.registerCommand('extension.openInGitHub', openInGitHub));
+    context.subscriptions.push(commands.registerCommand('extension.copyGitHubLinkToClipboard', copyGitHubLinkToClipboard));
 }
 
 exports.activate = activate;


### PR DESCRIPTION
I have implemented this functionality using GitHub link providing logic extracted from openInGitHub function and copy-paste npm package.

This resolves #21 .