### PR TITLE
Fix open link from editor

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -104,10 +104,9 @@ function getGitHubLinkForRepo(cb) {
     getGitHubLink(cb);
 }
 
-function branchOnCallingContext(contexMenuParam, cb){
-    if (contexMenuParam !== undefined) {
-        fileFsPath = contexMenuParam._fsPath;
-        getGitHubLinkForFile(fileFsPath, cb);
+function branchOnCallingContext(args, cb){
+    if (args && args.fsPath) {
+        getGitHubLinkForFile(args.fsPath, cb);
     }
     else if (Window.activeTextEditor) {
         getGitHubLinkForCurrentEditorLine(cb);
@@ -117,12 +116,12 @@ function branchOnCallingContext(contexMenuParam, cb){
     }
 }
 
-function openInGitHub(contexMenuParam) {
-    branchOnCallingContext(contexMenuParam, open);
+function openInGitHub(args) {
+    branchOnCallingContext(args, open);
 }
 
-function copyGitHubLinkToClipboard(contexMenuParam) {
-    branchOnCallingContext(contexMenuParam, copy);
+function copyGitHubLinkToClipboard(args) {
+    branchOnCallingContext(args, copy);
 }
 
 function activate(context) {


### PR DESCRIPTION
Since last update the extension was failing when you want to open a line from the editor. It always opened the tree for that branch.

Apparently the `contexMenuParam` is always send, even from the editor, reviewing vscode docs they call this parameter just `args`, I renamed it to avoid any confusion with only "menu context" parameter.

I used the "public" field `fsPath` instead of `_fsPath`.

I tested it in 0.10.3 and 1.3.1, it worked in both. Using 1.3.1 I checked the context menu use case was working as well.

Fixes: https://github.com/ziyasal/vscode-open-in-github/issues/33