### PR TITLE
Remove dash from GitLab line url hash

### DIFF
--- a/src/gitProvider.js
+++ b/src/gitProvider.js
@@ -54,7 +54,7 @@ class Bitbucket extends BaseProvider {
 class GitLab extends GitHub {
     webUrl(branch, filePath, line, endLine) {
         if (filePath) {
-            return `${this.baseUrl}/blob/${branch}` + (filePath ? `${filePath}` : '') + (line ? `#L-${line}` : '');
+            return `${this.baseUrl}/blob/${branch}` + (filePath ? `${filePath}` : '') + (line ? `#L${line}` : '');
         }
         return `${this.baseUrl}/tree/${branch}`;
     }


### PR DESCRIPTION
GitLab urls to a specific line in a file are formatted without a dash `#L[number]`. Example: https://gitlab.com/Rich-Harris/buble/blob/master/src/index.js#L10

Fixes #59