### PR TITLE
open by default remote without set branch

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -37,14 +37,21 @@ function getGitProviderLink(cb, fileFsPath, lines, pr) {
             // Check to see if the branch has a configured remote
             configuredBranch = config[`branch "${branch}"`];
 
-            if (!configuredBranch) {
+            if (configuredBranch) {
+                // Use the current branch's configured remote
+                remoteName = configuredBranch.remote;
+                rawUri = config[`remote "${remoteName}"`].url;
+            } else {
+                const remotes = Object.keys(config).filter(k => k.startsWith('remote '));
+                if (remotes.length > 0) {
+                    rawUri = config[remotes[0]].url;
+                }
+            }
+
+            if (!rawUri) {
                 Window.showWarningMessage(`No remote found on branch.`);
                 return;
             }
-
-            // Use the current branch's configured remote
-            remoteName = configuredBranch.remote;
-            rawUri = config[`remote "${remoteName}"`].url;
 
             try {
                 provider = gitProvider(rawUri);


### PR DESCRIPTION
Here are my git config file example:

``` 
[core]
	repositoryformatversion = 0
	filemode = false
	bare = false
	logallrefupdates = true
	symlinks = false
	ignorecase = true
[remote "origin"]
	url = XXXXXXXXXXXXXXXXXXXXXXXXX
	fetch = +refs/heads/*:refs/remotes/origin/*
	puttykeyfile = YYYYYYYYYYYYYYYYYYYYYYYYYYYYY
```