### PR TITLE
FIX: Sort the anchor line and active line in ascending order

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -148,7 +148,7 @@ function getSelectedLines(editor) {
     var anchorLineIndex = editor.selection.anchor.line + 1;
     var activeLineIndex = editor.selection.active.line + 1;
 
-    return [anchorLineIndex, activeLineIndex].sort();
+    return [anchorLineIndex, activeLineIndex].sort(function(a, b) { return a - b });
 }
 
 function getGitProviderLinkForRepo(cb) {


### PR DESCRIPTION
When the selection satisfies certain conditions in the editor, the URL of Github created with this extension is incorrect.

Example:
1. I select lines 7 to 15 of this repository with VS Code
2. Use vscode-open-in-github to open github
3. The end of the URL becomes L15 - L7 (the corresponding line is not highlighted)

Capture:
![ff](https://user-images.githubusercontent.com/535254/31831025-f4177fa6-b5fc-11e7-99be-5e879aacba0c.gif)

There is a problem with the `sort()` methods used to rearrange the start and end points of the selection.

The `sort()` methods is  sorted according to each character's Unicode code point value, according to the string conversion of each element.
 [Referrence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)

I specified compareFunction so that I compare array elements by the size of numbers and sort them.