### PR TITLE
[Bugfix] ".git" removed if repository name is <user>.github.io

### DIFF
--- a/src/gitProvider.js
+++ b/src/gitProvider.js
@@ -10,7 +10,7 @@ class BaseProvider {
     }
 
     get baseUrl() {
-        return this.gitUrl.toString('https').replace(/\.git/, '');
+        return this.gitUrl.toString('https').replace(/(\.git)$/, '');
     }
 
     /**


### PR DESCRIPTION
# Bugfix - ".git" removed if repository name is .github.io

This PR addresses Issue https://github.com/ziyasal/vscode-open-in-github/issues/73

## Context

I have a repository `abinavseelan.github.io`. When I use the extension to go to a specific line, the final url that I'm taken to is `https://github.com/abinavseelan/abinavseelanhub.io/blob/master/index.html#L16-L24`

The `.git` in `abinavseelan.github.io` is removed.

## The Fix

- Modified the regex to remove `.git` only if it's present at the **end** of  `this.gitUrl`.

😄 