### PR TITLE
fix: Add parameter to specify http or https url

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Add following line into workspace settings;
 
 ```js
 {
-  "openInGitHub.gitHubDomain":"your custom github domain here",
-  "openInGitHub.requireSelectionForLines":false   // If enabled, the copied or opened URL won't include line number(s) unless there's an active selection
+  "openInGitHub.gitHubDomain": "your custom github domain here",
+  "openInGitHub.requireSelectionForLines": false,   // If enabled, the copied or opened URL won't include line number(s) unless there's an active selection
   "openInGitHub.providerType": "gitlab" //github, gitlab, bitbucket, ...
+  "openInGitHub.providerProtocol": "https" //https, http. Useful for custom domains that don't support https. Defaults to https.
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
             "string"
           ],
           "default": "github.com",
-          "description": "Configure a custom Github domain. Useful for Github entreprise"
+          "description": "Configure a custom Github domain. Useful for Github enterprise"
         },
         "openInGitHub.requireSelectionForLines": {
           "type": "boolean",
@@ -69,7 +69,16 @@
               "github",
               "bitbucket"
           ],
-          "description": "specify the provider type in Custom Site"
+          "description": "Specify the provider type in Custom Site"
+        },
+        "openInGitHub.providerProtocol": {
+          "type": "string",
+          "default": "https",
+          "enum": [
+              "https",
+              "http"
+          ],
+          "description": "Specify the provider protocol for custom sites or Github enterprise"
         }
       }
     },

--- a/src/gitProvider.js
+++ b/src/gitProvider.js
@@ -10,7 +10,7 @@ class BaseProvider {
     }
 
     get baseUrl() {
-        return this.gitUrl.toString('https').replace(/(\.git)$/, '');
+        return this.gitUrl.toString(providerProtocol).replace(/(\.git)$/, '');
     }
 
     /**
@@ -90,6 +90,7 @@ class VisualStudio extends BaseProvider {
 
 const gitHubDomain = workspace.getConfiguration('openInGitHub').get('gitHubDomain', 'github.com');
 const providerType = workspace.getConfiguration('openInGitHub').get('providerType', 'unknown');
+const providerProtocol = workspace.getConfiguration('openInGitHub').get('providerProtocol', 'https');
 
 const providers = {
     [gitHubDomain]: GitHub,

--- a/test/gitProvider.test.js
+++ b/test/gitProvider.test.js
@@ -80,6 +80,38 @@ suite('gitProvider', function () {
                 });
             });
         });
+
+        suite('with custom domain and protocol', function () {
+            const testDomain = 'github.testdomain.com';
+            const testProtocol = 'http';
+            const remoteUrl = `https://${testDomain}/${userName}/${repoName}.git`;
+
+            const fakeVscode = {
+                workspace: {
+                    getConfiguration: function () {
+                        return {
+                            get: function (configKey) {
+                                if (configKey === 'gitHubDomain') {
+                                    return testDomain;
+                                } else if (providerProtocol === 'providerProtocol') {
+                                    return testProtocol;
+                                }
+                            },
+                        };
+                    },
+                },
+            };
+            const gitProvider = proxyquire('../src/gitProvider.js', { vscode: fakeVscode });
+            const provider = gitProvider(remoteUrl);
+
+            suite('#webUrl(branch, filePath)', function () {
+                test('should return custom domain URL', function () {
+                    const expectedUrl = `http://${testDomain}/${userName}/${repoName}/blob/${branch}${filePath}`;
+                    const webUrl = provider.webUrl(branch, filePath);
+                    expect(webUrl).to.equal(expectedUrl);
+                });
+            });
+        });
     });
 
     suite('Bitbucket', function () {


### PR DESCRIPTION
Closes #65.

I could not get the tests to run locally. I did test my changes by installing the extension manually and adjusting the workspace settings.