### PR TITLE
added known limitations to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Have fun..
 
 Reference: [Stackoverflow](https://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally)
 
+## Known Limitations
+- Extension doesn't currently works with Git worktrees
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):


### PR DESCRIPTION
Took me a while to figure out why the extension wasn't working. Apparently it fails silently when using Worktrees.
Thought it would be great to have that mentioned until it gets resolved.