### PR TITLE
support worktrees

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -103,11 +103,20 @@ function locateGitConfig(repoDir) {
                     if (err) {
                         reject(err);
                     }
+                    
                     var match = data.match(/gitdir: (.*)/)[1];
                     if (!match) {
                         reject('Unable to find gitdir in .git file');
                     }
                     var configPath = path.join(repoDir, match, 'config');
+                    
+                    // for worktrees traverse up to the main .git folder
+                    var workTreeMatch = match.match(/\.git\/worktrees*/);
+                    if(workTreeMatch) {
+                        var mainGitFolder = match.slice(0, workTreeMatch.index);
+                        var configPath = path.join(mainGitFolder, '.git','config');
+                        
+                    }
                     resolve(configPath);
                 });
             } else {
@@ -121,6 +130,7 @@ function readConfigFile(path) {
     return new Promise((resolve, reject) => {
         fs.readFile(path, 'utf-8', (err, data) => {
             if (err) {
+                console.error(err);
                 reject(err);
             }
             resolve(ini.parse(data));


### PR DESCRIPTION
Add support for Worktrees by checking if it has `./git/worktrees` in the path.
If it does, it slice the path to the repo and adds `/.git/config`.

Works in my case, not sure if it's going to work in every case (I think it should)

Fixes #111